### PR TITLE
fixed gtask selection in task edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 local.properties
 Thumbs.db
 /captures/
+/sync.ffs_db

--- a/app/src/main/java/org/tasks/gtasks/GtaskSyncAdapterHelper.java
+++ b/app/src/main/java/org/tasks/gtasks/GtaskSyncAdapterHelper.java
@@ -63,8 +63,7 @@ public class GtaskSyncAdapterHelper {
     }
 
     public boolean isEnabled() {
-        return preferences.getBoolean(R.string.sync_gtasks, false) &&
-                playServices.isPlayServicesAvailable() &&
+        return playServices.isPlayServicesAvailable() &&
                 hasAccounts();
     }
 


### PR DESCRIPTION
In Task Edit screen sync selection was not available when no webdav account was set